### PR TITLE
Improve compatibility of clades definition file and update main_depict_clades.R

### DIFF
--- a/src/R/main_depict_clades.R
+++ b/src/R/main_depict_clades.R
@@ -91,8 +91,8 @@ if (ST) {
 cols <- c( "ID" , "CLADE", "BOOT")
 #Read Raw files
  read.data <- function (file.all=paste(input, "/clades.txt.res", sep=""), file.hs=paste(input, "clades.hs.txt.res", sep=""), clade.order = NULL, new.clades = NULL, new.models = NULL, techs.order = NULL) {
-  raw.all = read.csv(file.all,sep="\t", header=T)
-  raw.highsupport = read.csv(file.hs,sep="\t", header=T)
+  raw.all = read.csv(file.all,sep="\t", header=T, as.is=F)
+  raw.highsupport = read.csv(file.hs,sep="\t", header=T, as.is=F)
   if (! is.null(techs.order)) {
     print("tech renaming...")
     raw.all$ID=factor(raw.all$ID,levels=techs.order)

--- a/src/utils/find_clades.py
+++ b/src/utils/find_clades.py
@@ -102,8 +102,8 @@ class Mono(object):
                 self.analyze_clade(k, v, clade_comp, tree, treeName, mult)
 
     def read_clades(self,filename):
-        for line in open(filename):
-            line = line.replace("\n","")
+        for line in open(filename, 'r'):
+            line = line.strip()
             sign = "+"
             r = line.split('\t')
             if r[0] == 'Clade Name':

--- a/src/utils/find_clades2.py
+++ b/src/utils/find_clades2.py
@@ -238,6 +238,7 @@ class Mono(object):
 	    elif len(r)<6:
 		self.othercomps[name] = othercomponents
             self.show[name] = show
+
 def getTaxa(cladeFiles):
 	try:	
 		f = open(cladeFiles, 'r')
@@ -252,7 +253,7 @@ def getTaxa(cladeFiles):
 			flag = 1
 			line = line.strip('\n')
 			listLine = line.split('\t')[1]
-			taxa = set(listLine.replace('""+""','\t').replace('""','\t').replace('"','\t').replace('+','\t').strip('\t').replace('\t\t','\t').split('\t'))
+			taxa = set(re.split(r'""\+""|""|"|\+', listLine))
 	if flag == 0:
 		print("Please define a clade with name All in your clade definition file, which includes all species in your dataset!")
 		sys.exit(1)


### PR DESCRIPTION
①、update main_depict_clades.R

> Warning messages:
> In type.convert.default(X[[i]], ...) :
> 'as.is' should be specified by the caller; using TRUE

When this occurs, R does not convert character vectors into factor vectors, which leads to certain functions (like levels()) returning NULL and subsequently, the inability to properly generate plots.

②、Improve compatibility of clades definition file

Make the taxa in the clades definition file can be read correctly without double quotes.